### PR TITLE
feat: add syntax highlighting in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.3.0 : Colours
+The REPL is now full of :sparkles: colours :sparkles:
+Fix the re-assignment bug
+
 # Version 3.2.0 : Differentiation #2 
 Differentiates all functions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mini-calc"
-version = "3.3.0-alpha"
+version = "3.3.0"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mini-calc"
-version = "3.2.0"
+version = "3.3.0-alpha"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-calc"
-version = "3.3.0-alpha"
+version = "3.3.0"
 license = "GPL-3.0-or-later"
 description = "A Fully-Featured Configurable (mini) Rust Calculator"
 homepage = "https://calc.charlotte-thomas.me"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "mini-calc"
-version = "3.2.0"
+version = "3.3.0-alpha"
 license = "GPL-3.0-or-later"
-description = "A fully-featured minimalistic configurable rust calculator"
-homepage = "https://calc.nwa2coco.fr"
-repository = "https://github.com/coco33920/calc"
+description = "A Fully-Featured Configurable (mini) Rust Calculator"
+homepage = "https://calc.charlotte-thomas.me"
+repository = "https://github.com/vanilla-extract/calc"
 readme = "README.md"
 edition = "2021"
 exclude = [

--- a/src/configuration/loader.rs
+++ b/src/configuration/loader.rs
@@ -131,7 +131,7 @@ pub fn load_color(string: String) -> Color {
 
 pub fn replace_variable(str: String) -> String {
     str.replace("%author%", "Charlotte Thomas")
-        .replace("%version%", "v3.2.0")
+        .replace("%version%", "v3.3.0-alpha")
         .to_string()
 }
 

--- a/src/configuration/loader.rs
+++ b/src/configuration/loader.rs
@@ -131,7 +131,7 @@ pub fn load_color(string: String) -> Color {
 
 pub fn replace_variable(str: String) -> String {
     str.replace("%author%", "Charlotte Thomas")
-        .replace("%version%", "v3.3.0-alpha")
+        .replace("%version%", "v3.3.0")
         .to_string()
 }
 

--- a/src/interpreting/interpreter.rs
+++ b/src/interpreting/interpreter.rs
@@ -70,7 +70,18 @@ pub fn interpret(
                         }
                     }
                     _ => {
-                        let (a, b) = assign(param1.clone(), param2.clone());
+                        let p1 = match *l.clone() {
+                            Ast::Node { value, left, right } => {
+                                match (value.clone(), *left, *right) {
+                                    (Parameters::Identifier(_), Ast::Nil, Ast::Nil) => {
+                                        value.clone()
+                                    }
+                                    _ => Parameters::Null,
+                                }
+                            }
+                            _ => Parameters::Null,
+                        };
+                        let (a, b) = assign(p1, param2.clone());
                         if a != "".to_string() {
                             if ram.contains_key(&a) {
                                 ram.remove(&a);

--- a/src/interpreting/interpreter.rs
+++ b/src/interpreting/interpreter.rs
@@ -43,15 +43,30 @@ pub fn interpret(
                 Parameters::Assign => match *(l.clone()) {
                     Ast::Call { name: n, lst: list } => {
                         if function.contains_key(&n) {
-                            Parameters::Str("This function has already been set".to_string())
+                            println!(
+                                "{}",
+                                ansi_term::Color::Red
+                                    .bold()
+                                    .paint("This function has already been set")
+                            );
+                            Parameters::Null
                         } else {
                             if n.as_str() != "" {
-                                (function).insert(n.to_string(), (list, *r.clone()));
+                                (function).insert(n.to_string(), (list.clone(), *r.clone()));
                             }
-                            Parameters::Identifier(format!(
-                                "@The function {} has been set",
-                                n.clone()
-                            ))
+                            println!(
+                                "{}: {} = {}",
+                                ansi_term::Color::Cyan.paint("fun"),
+                                ansi_term::Color::RGB(255, 215, 0).paint(format!(
+                                    "{}",
+                                    Ast::Call {
+                                        name: n.clone(),
+                                        lst: list.clone()
+                                    }
+                                )),
+                                ansi_term::Color::RGB(255, 215, 0).paint(format!("{}", *r.clone()))
+                            );
+                            Parameters::Null
                         }
                     }
                     _ => {
@@ -62,11 +77,17 @@ pub fn interpret(
                             }
                             (ram).insert(a.clone(), b.clone());
 
-                            return Parameters::Identifier(format!(
-                                "@ {} = {}",
-                                a.clone(),
-                                b.clone().pretty_print(Some(ram), Some(function))
-                            ));
+                            println!(
+                                "{}: {} = {}",
+                                ansi_term::Color::Cyan.paint("assign"),
+                                ansi_term::Color::Yellow.paint(format!("{}", a.clone())),
+                                ansi_term::Color::Yellow.paint(format!(
+                                    "{}",
+                                    b.clone().pretty_print(Some(ram), Some(function))
+                                ))
+                            );
+
+                            return Parameters::Null;
                         }
                         Parameters::Null
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ fn main() {
         if result != Parameters::Null {
             println!(
                 "{}",
-                result.pretty_print(Some(&mut ram), Some(&mut functions))
+                result.argument_print(Some(&mut ram), Some(&mut functions))
             )
         }
         exit(0);
@@ -426,7 +426,7 @@ fn main() {
                     if result != Parameters::Null {
                         println!(
                             "{}",
-                            result.pretty_print(Some(&mut ram), Some(&mut functions))
+                            result.argument_print(Some(&mut ram), Some(&mut functions))
                         )
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,7 @@ fn main() {
         if result != Parameters::Null {
             println!(
                 "{}",
-                result.argument_print(Some(&mut ram), Some(&mut functions))
+                result.pretty_print(Some(&mut ram), Some(&mut functions))
             )
         }
         exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn handle_config(line: &str, config: Config) -> (String, Option<Config>) {
 fn main() {
     let mut args: Args = env::args();
 
-    let version: String = "v3.2.0".to_string();
+    let version: String = "v3.3.0-alpha".to_string();
     if args.len() > 1 || !atty::is(Stream::Stdin) {
         let mut a = vec![];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn handle_config(line: &str, config: Config) -> (String, Option<Config>) {
 fn main() {
     let mut args: Args = env::args();
 
-    let version: String = "v3.3.0-alpha".to_string();
+    let version: String = "v3.3.0".to_string();
     if args.len() > 1 || !atty::is(Stream::Stdin) {
         let mut a = vec![];
 

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+use ansi_term::Color;
+
 use crate::exact_math::rationals::Rationals;
 use crate::lexing::token::{Operator, Token};
 use crate::parsing::ast::Ast::{Nil, Node};
@@ -396,28 +398,75 @@ impl Parameters {
         function: Option<&mut HashMap<String, (Vec<Ast>, Ast)>>,
     ) -> String {
         match self.clone() {
-            Int(_) => format!("val: int = {}", self.pretty_print(ram, function)),
-            Float(_) => format!("val: float = {}", self.pretty_print(ram, function)),
+            Int(_) => format!(
+                "{}: {} = {}",
+                Color::Cyan.paint("val"),
+                Color::Green.paint("int"),
+                Color::Green.paint(self.pretty_print(ram, function))
+            ),
+            Float(_) => format!(
+                "{}: {} = {}",
+                Color::Cyan.paint("val"),
+                Color::White.paint("float"),
+                Color::White.paint(self.pretty_print(ram, function))
+            ),
             Identifier(s) => {
                 if s.starts_with("@") {
                     self.pretty_print(ram, function)
                 } else {
-                    format!("val: ident = {}", self.pretty_print(ram, function))
+                    format!(
+                        "{}: {} = {}",
+                        Color::Cyan.paint("val"),
+                        Color::Yellow.paint("ident"),
+                        Color::Yellow.paint(self.pretty_print(ram, function))
+                    )
                 }
             }
-            Rational(_) => format!("val: rational = {}", self.pretty_print(ram, function)),
-            Bool(_) => format!("val: bool = {}", self.pretty_print(ram, function)),
+            Rational(_) => format!(
+                "{}: {} = {}",
+                Color::Cyan.paint("val"),
+                Color::Yellow.paint("rational"),
+                Color::Yellow.paint(self.pretty_print(ram, function)),
+            ),
+            Bool(_) => format!(
+                "{}: {} = {}",
+                Color::Cyan.paint("val"),
+                Color::Yellow.paint("bool"),
+                Color::Yellow.paint(self.pretty_print(ram, function)),
+            ),
             InterpreterVector(_) => {
-                format!("val: matrix \n{}", self.pretty_print(ram, function))
+                format!(
+                    "{}: {} \n{}",
+                    Color::Cyan.paint("val"),
+                    Color::Purple.paint("matrix"),
+                    Color::Purple.paint(self.pretty_print(ram, function))
+                )
             }
             Var(_, _, _) => {
-                format!("val: var = {}", self.pretty_print(ram, function))
+                format!(
+                    "{}: {} = {}",
+                    Color::Cyan.paint("val"),
+                    Color::Purple.paint("var"),
+                    Color::Purple.paint(self.pretty_print(ram, function))
+                )
             }
             Plus(_, _) | Mul(_, _) | Div(_, _) => {
-                format!("val: op = {}", self.pretty_print(ram, function))
+                format!(
+                    "{}: {} = {}",
+                    Color::Cyan.paint("val"),
+                    Color::Red.paint("op"),
+                    Color::Red.paint(self.pretty_print(ram, function))
+                )
             }
             Str(_) => {
-                format!("val: string = \"{}\"", self.pretty_print(ram, function))
+                format!(
+                    "{}: {} = {}{}{}",
+                    Color::Cyan.paint("val"),
+                    Color::Blue.paint("string"),
+                    Color::Blue.paint("\""),
+                    Color::Blue.paint(self.pretty_print(ram, function)),
+                    Color::Blue.paint("\"")
+                )
             }
 
             _ => self.pretty_print(ram, function),

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -396,26 +396,30 @@ impl Parameters {
         function: Option<&mut HashMap<String, (Vec<Ast>, Ast)>>,
     ) -> String {
         match self.clone() {
-            Int(_) => format!("val = int: {}", self.pretty_print(ram, function)),
-            Float(_) => format!("val = float: {}", self.pretty_print(ram, function)),
+            Int(_) => format!("val: int = {}", self.pretty_print(ram, function)),
+            Float(_) => format!("val: float = {}", self.pretty_print(ram, function)),
             Identifier(s) => {
                 if s.starts_with("@") {
                     self.pretty_print(ram, function)
                 } else {
-                    format!("val = ident: {}", self.pretty_print(ram, function))
+                    format!("val: ident = {}", self.pretty_print(ram, function))
                 }
             }
-            Rational(_) => format!("val = rational: {}", self.pretty_print(ram, function)),
-            Bool(_) => format!("val = bool: {}", self.pretty_print(ram, function)),
+            Rational(_) => format!("val: rational = {}", self.pretty_print(ram, function)),
+            Bool(_) => format!("val: bool = {}", self.pretty_print(ram, function)),
             InterpreterVector(_) => {
-                format!("val = matrix: \n{}", self.pretty_print(ram, function))
+                format!("val: matrix \n{}", self.pretty_print(ram, function))
             }
             Var(_, _, _) => {
-                format!("val = var: {}", self.pretty_print(ram, function))
+                format!("val: var = {}", self.pretty_print(ram, function))
             }
             Plus(_, _) | Mul(_, _) | Div(_, _) => {
-                format!("val = op: {}", self.pretty_print(ram, function))
+                format!("val: op = {}", self.pretty_print(ram, function))
             }
+            Str(_) => {
+                format!("val: string = \"{}\"", self.pretty_print(ram, function))
+            }
+
             _ => self.pretty_print(ram, function),
         }
     }

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -407,8 +407,8 @@ impl Parameters {
             Float(_) => format!(
                 "{}: {} = {}",
                 Color::Cyan.paint("val"),
-                Color::White.paint("float"),
-                Color::White.paint(self.pretty_print(ram, function))
+                Color::RGB(186, 214, 152).paint("float"),
+                Color::RGB(186, 214, 152).paint(self.pretty_print(ram, function))
             ),
             Identifier(s) => {
                 if s.starts_with("@") {
@@ -425,29 +425,29 @@ impl Parameters {
             Rational(_) => format!(
                 "{}: {} = {}",
                 Color::Cyan.paint("val"),
-                Color::Yellow.paint("rational"),
-                Color::Yellow.paint(self.pretty_print(ram, function)),
+                Color::RGB(237, 138, 35).paint("rational"),
+                Color::RGB(237, 138, 35).paint(self.pretty_print(ram, function)),
             ),
             Bool(_) => format!(
                 "{}: {} = {}",
                 Color::Cyan.paint("val"),
-                Color::Yellow.paint("bool"),
-                Color::Yellow.paint(self.pretty_print(ram, function)),
+                Color::RGB(234, 144, 144).paint("bool"),
+                Color::RGB(234, 144, 144).paint(self.pretty_print(ram, function)),
             ),
             InterpreterVector(_) => {
                 format!(
                     "{}: {} \n{}",
                     Color::Cyan.paint("val"),
-                    Color::Purple.paint("matrix"),
-                    Color::Purple.paint(self.pretty_print(ram, function))
+                    Color::RGB(248, 204, 249).paint("matrix"),
+                    Color::RGB(248, 204, 249).paint(self.pretty_print(ram, function))
                 )
             }
             Var(_, _, _) => {
                 format!(
                     "{}: {} = {}",
                     Color::Cyan.paint("val"),
-                    Color::Purple.paint("var"),
-                    Color::Purple.paint(self.pretty_print(ram, function))
+                    Color::RGB(30, 154, 176).paint("var"),
+                    Color::RGB(30, 154, 176).paint(self.pretty_print(ram, function))
                 )
             }
             Plus(_, _) | Mul(_, _) | Div(_, _) => {

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -416,7 +416,7 @@ impl Parameters {
                 } else {
                     format!(
                         "{}: {} = {}",
-                        Color::Cyan.paint("val"),
+                        Color::Cyan.paint(format!("{}", s.clone())),
                         Color::Yellow.paint("ident"),
                         Color::Yellow.paint(self.pretty_print(ram, function))
                     )

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -390,6 +390,35 @@ impl Parameters {
             _ => format!("{self}"),
         }
     }
+    pub fn argument_print(
+        &self,
+        ram: Option<&mut HashMap<String, Parameters>>,
+        function: Option<&mut HashMap<String, (Vec<Ast>, Ast)>>,
+    ) -> String {
+        match self.clone() {
+            Int(_) => format!("val = int: {}", self.pretty_print(ram, function)),
+            Float(_) => format!("val = float: {}", self.pretty_print(ram, function)),
+            Identifier(s) => {
+                if s.starts_with("@") {
+                    self.pretty_print(ram, function)
+                } else {
+                    format!("val = ident: {}", self.pretty_print(ram, function))
+                }
+            }
+            Rational(_) => format!("val = rational: {}", self.pretty_print(ram, function)),
+            Bool(_) => format!("val = bool: {}", self.pretty_print(ram, function)),
+            InterpreterVector(_) => {
+                format!("val = matrix: \n{}", self.pretty_print(ram, function))
+            }
+            Var(_, _, _) => {
+                format!("val = var: {}", self.pretty_print(ram, function))
+            }
+            Plus(_, _) | Mul(_, _) | Div(_, _) => {
+                format!("val = op: {}", self.pretty_print(ram, function))
+            }
+            _ => self.pretty_print(ram, function),
+        }
+    }
 }
 
 pub fn token_to_parameter(token: Token) -> Parameters {


### PR DESCRIPTION
Implements #52 

*Legends:*
:rocket: need to release v3.3.0
:rightwards_hand: nice to have to release v3.3.0

- [x] Highlighting of result :rightwards_hand: 
  - [x] Type highlighting :rocket: 
  - [x] Value highlighting :rightwards_hand: 
    - [x] Integer :rocket: 
    - [x] String :rocket: 
    - [x] Rationals :rocket: 
    - [x] Matrices :rightwards_hand: 
    - [x] Vectors :-1: 
    - [x] functions :-1: 
    - [x] Variable :-1: 
  - [x] Function creation highlighting :rightwards_hand: 
  - [x] Variable setting highlighting  :rightwards_hand: 
  
    
    Thanks @leana8959 for the suggestion :)