### PR TITLE
feat: basic implementation of conditional expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 target/
 manual/mantys
-Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean
+SHELL=/bin/bash
+
+build:
+	cargo build
+release:
+	cargo build --release
+clean:
+	cargo clean
+watch: build
+	cargo watch -x fmt -x run

--- a/src/interpreting/interpreter.rs
+++ b/src/interpreting/interpreter.rs
@@ -149,8 +149,9 @@ pub fn interpret(ast: &Ast, mut ram: &mut Ram, mut function: &mut Functions) -> 
                     interpret(else_branch, ram, function)
                 }
             } else {
-                // HACK: how to propagate this error upwards
-                panic!("dodo")
+                Parameters::Identifier(
+                    "@Runtime exception, condition did not collapse to a bool".to_string(),
+                )
             }
         }
     }

--- a/src/interpreting/interpreter.rs
+++ b/src/interpreting/interpreter.rs
@@ -137,6 +137,22 @@ pub fn interpret(ast: &Ast, mut ram: &mut Ram, mut function: &mut Functions) -> 
             let v: Vec<Parameters> = list.iter().map(|x| interpret(x, ram, function)).collect();
             exec(n.to_string(), v, Some(&mut ram), Some(&mut function))
         }
+        Ast::Conditional {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            if let Parameters::Bool(condition_bool) = interpret(condition, ram, function) {
+                if condition_bool {
+                    interpret(then_branch, ram, function)
+                } else {
+                    interpret(else_branch, ram, function)
+                }
+            } else {
+                // HACK: how to propagate this error upwards
+                panic!("dodo")
+            }
+        }
     }
 }
 

--- a/src/interpreting/stdlib.rs
+++ b/src/interpreting/stdlib.rs
@@ -69,6 +69,8 @@ pub fn exec(s: String, lst: Vec<Parameters>, ram: Ram, functions: Functions) -> 
                         match v {
                             Ast::Nil => (),
                             Ast::Call { .. } => (),
+                            // TODO: what are the implications of this
+                            Ast::Conditional { .. } => (),
                             Ast::Node {
                                 value: v,
                                 left: _l,
@@ -2048,6 +2050,8 @@ pub fn plot_fn(
                     match v {
                         Ast::Nil => (),
                         Ast::Call { .. } => (),
+                        // TODO: What are the implications of this
+                        Ast::Conditional { .. } => (),
                         Ast::Node {
                             value: v,
                             left: _l,

--- a/src/interpreting/stdlib.rs
+++ b/src/interpreting/stdlib.rs
@@ -69,7 +69,6 @@ pub fn exec(s: String, lst: Vec<Parameters>, ram: Ram, functions: Functions) -> 
                         match v {
                             Ast::Nil => (),
                             Ast::Call { .. } => (),
-                            // TODO: what are the implications of this
                             Ast::Conditional { .. } => (),
                             Ast::Node {
                                 value: v,
@@ -2050,7 +2049,6 @@ pub fn plot_fn(
                     match v {
                         Ast::Nil => (),
                         Ast::Call { .. } => (),
-                        // TODO: What are the implications of this
                         Ast::Conditional { .. } => (),
                         Ast::Node {
                             value: v,

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -289,6 +289,12 @@ pub fn lex(input: String) -> Vec<Token> {
                         vec.push(Token::OPE(GreaterThan))
                     } else if &a == "eq" {
                         vec.push(Token::OPE(EQUALITY))
+                    } else if &a == "if" {
+                        vec.push(Token::IF)
+                    } else if &a == "then" {
+                        vec.push(Token::THEN)
+                    } else if &a == "else" {
+                        vec.push(Token::ELSE)
                     } else {
                         vec.push(Token::IDENTIFIER(a))
                     }

--- a/src/lexing/token.rs
+++ b/src/lexing/token.rs
@@ -35,6 +35,9 @@ pub enum Token {
     WHITESPACE,
     PreAnd,
     PreOr,
+    IF,
+    THEN,
+    ELSE,
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
@@ -65,6 +68,9 @@ pub enum TokenType {
     WHITESPACE,
     EXPO,
     QUOTE,
+    IF,
+    THEN,
+    ELSE,
 }
 
 pub enum Precedence {
@@ -119,6 +125,9 @@ impl Display for Token {
             Token::LBRACKET => write!(f, "["),
             Token::QUOTE => write!(f, "\""),
             Token::WHITESPACE => write!(f, " "),
+            Token::IF => write!(f, "if"),
+            Token::THEN => write!(f, "then"),
+            Token::ELSE => write!(f, "else"),
         }
     }
 }
@@ -154,6 +163,9 @@ impl Token {
             Token::RBRACKET => TokenType::RBRACKET,
             Token::QUOTE => TokenType::QUOTE,
             Token::WHITESPACE => TokenType::WHITESPACE,
+            Token::IF => TokenType::IF,
+            Token::ELSE => TokenType::ELSE,
+            Token::THEN => TokenType::THEN,
             _ => TokenType::Null,
         }
     }

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -59,6 +59,11 @@ pub enum Ast {
         name: String,
         lst: Vec<Ast>,
     },
+    Conditional {
+        condition: Box<Ast>,
+        then_branch: Box<Ast>,
+        else_branch: Box<Ast>,
+    },
 }
 
 pub fn int_to_superscript_string(i: i64) -> String {
@@ -150,6 +155,13 @@ impl Display for Ast {
                 let mut vs = Vec::new();
                 s.iter().for_each(|x1| vs.push(x1.to_string()));
                 write!(f, "{}({})", v, vs.join(",").to_string())
+            }
+            Ast::Conditional {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                write!(f, "if {condition} then {then_branch} else {else_branch}")
             }
         }
     }

--- a/src/parsing/parselets/prefix_parselet.rs
+++ b/src/parsing/parselets/prefix_parselet.rs
@@ -24,6 +24,9 @@ pub struct VecParselet {}
 #[derive(Clone)]
 pub struct QuoteParselet {}
 
+#[derive(Clone)]
+pub struct IfThenElseParselet {}
+
 impl PrefixParselet for ValueParselet {
     fn parse(&self, _parser: &mut CalcParser, token: Token) -> Ast {
         Ast::Node {
@@ -99,6 +102,22 @@ impl PrefixParselet for QuoteParselet {
             value: crate::parsing::ast::Parameters::Str(str.trim().to_string()),
             left: Box::new(Ast::Nil),
             right: Box::new(Ast::Nil),
+        }
+    }
+}
+
+impl PrefixParselet for IfThenElseParselet {
+    fn parse(&self, parser: &mut CalcParser, _token: Token) -> Ast {
+        let cond_expr = parser.parse_expression_empty();
+        parser.consume_expected(TokenType::THEN);
+        let lhs = parser.parse_expression_empty();
+        parser.consume_expected(TokenType::ELSE);
+        let rhs = parser.parse_expression_empty();
+
+        Ast::Conditional {
+            condition: cond_expr.into(),
+            then_branch: lhs.into(),
+            else_branch: rhs.into(),
         }
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -10,7 +10,7 @@ use crate::parsing::parselets::prefix_parselet::{
     GroupParselet, NullParselet, OperatorPrefixParselet, PrefixParselet, ValueParselet,
 };
 
-use super::parselets::prefix_parselet::{QuoteParselet, VecParselet};
+use super::parselets::prefix_parselet::{IfThenElseParselet, QuoteParselet, VecParselet};
 
 #[derive(Clone)]
 pub struct CalcParser<'a> {
@@ -184,6 +184,7 @@ impl CalcParser<'_> {
             TokenType::GREATEREQ => Some(Box::from(OperatorPrefixParselet {})),
             TokenType::LBRACKET => Some(Box::from(VecParselet {})),
             TokenType::QUOTE => Some(Box::from(QuoteParselet {})),
+            TokenType::IF => Some(Box::from(IfThenElseParselet {})),
             _ => Some(Box::from(NullParselet {})),
         }
     }


### PR DESCRIPTION
I did a basic implementation of the condition structure. Relates to #56.
I'm saying "basic" because the issues I mentioned in #56 are not fully addressed.

Also, there's no type checking of the two branches, we do not currently enforce the type of the two branches to be the same.

Note that I skipped the implementation of `exec` and `plot`, I suppose they are related to function calls and plotting, which I do not know how conditionals should be have.

<details>

<summary>The ideas and reading that lead to this</summary>

I just read an article [here](https://journal.stuffwithstuff.com/2011/03/19/pratt-parsers-expression-parsing-made-easy/) about pratt parsing, it's pretty well written.

They talked about the `:?` ternary mixfix operator. In this case, it's the responsibility of `:` parselet to handle the right-hand-side of the expression, and there is only one possibility which is `<expr> ? <expr>`.

If we were to use the `if-else-then` (or `if-else-maybe-then`) syntax, it would be even less ambiguous since any conditional expression would be prefixed with if -- upon this token we can commit to the path of conditional, and if the text doesn't fit there's no need to backtrack, the error is certain.

Based on that idea, we can say "upon seeing the `if` token, handle the rest in a single prefix parselet".



</details>

<details>

<summary>An example</summary>

![image](https://github.com/user-attachments/assets/75750028-42a8-4ee9-93f6-320118f56fc5)

</details>

Let me know what you think!