### PR TITLE
chore: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,30 +5,31 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706826059,
-        "narHash": "sha256-N69Oab+cbt3flLvYv8fYnEHlBsWwdKciNZHUbynVEOA=",
+        "lastModified": 1748026106,
+        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25e3d4c0d3591c99929b1ec07883177f6ea70c9d",
+        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -36,8 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -52,39 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,40 +2,32 @@
   description = "A fully-featured minimalistic configurable rust calculator.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
-    utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        cargoTOML = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      in
-      rec {
-        devShell = pkgs.mkShell {
-          inputsFrom = [ packages.calc ];
-          packages = [ pkgs.gnumake ];
-        };
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in rec {
+      devShell = pkgs.mkShell {
+        inputsFrom = [packages.calc];
+        packages = [
+          pkgs.gnumake
+          pkgs.rust-analyzer
+          pkgs.rustfmt
+        ];
+      };
 
-        formatter = pkgs.nixpkgs-fmt;
-        packages = rec {
-          default = calc;
-          calc = pkgs.rustPlatform.buildRustPackage {
-            inherit (cargoTOML.package) version;
+      formatter = pkgs.alejandra;
 
-            pname = "calc";
-            src = ./.;
-
-            nativeBuildInputs = [ pkgs.makeWrapper ];
-            postFixup = ''
-              wrapProgram $out/bin/mini-calc \
-                --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gnuplot ]}"
-            '';
-
-            cargoLock.lockFile = ./Cargo.lock;
-            meta.mainProgram = "mini-calc";
-          };
-        };
-      });
+      packages = {
+        default = packages.calc;
+        calc = pkgs.callPackage ./nix/package.nix {};
+      };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A fully-featured minimalistic configurable rust calculator.";
+  description = "A Fully-Featured Configurable (mini) Rust Calculator.";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,23 @@
+{
+  rustPlatform,
+  lib,
+  makeWrapper,
+  gnuplot,
+}: let
+  cargoTOML = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+  rustPlatform.buildRustPackage {
+    inherit (cargoTOML.package) version;
+
+    pname = "calc";
+    src = ../.;
+
+    nativeBuildInputs = [makeWrapper];
+    postFixup = ''
+      wrapProgram $out/bin/mini-calc \
+        --prefix PATH : "${lib.makeBinPath [gnuplot]}"
+    '';
+
+    cargoLock.lockFile = ../Cargo.lock;
+    meta.mainProgram = "mini-calc";
+  }


### PR DESCRIPTION
This updates the nix shell. The current one was too old to build the project. (Rust 1.74 or something.)

The `package.nix` is also broken apart, allowing more flexible usage in downstream.